### PR TITLE
Add Boxplot visualization

### DIFF
--- a/static/js/boxplot.js
+++ b/static/js/boxplot.js
@@ -1,0 +1,49 @@
+'use strict';
+
+let boxplotRef = null;
+
+function buildBoxplot(range) {
+  const ctx = document.getElementById('boxplot_chart').getContext('2d');
+  if (boxplotRef) boxplotRef.destroy();
+
+  const slicedData = chartData.map(([id, label, data]) => {
+    return {
+      label: label,
+      data: data.slice(range[0], range[1])
+    };
+  }).filter(d => d.data.length > 0);
+
+  boxplotRef = new Chart(ctx, {
+    type: 'boxplot',
+    data: {
+      labels: slicedData.map(d => d.label),
+      datasets: [{
+        label: 'Verteilung',
+        backgroundColor: '#3498db',
+        borderColor: '#2980b9',
+        borderWidth: 1,
+        outlierColor: '#e74c3c',
+        padding: 10,
+        itemRadius: 0,
+        data: slicedData.map(d => d.data)
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { labels: { color: '#f8f9fa' } }
+      },
+      scales: {
+        x: {
+          ticks: { color: '#f8f9fa' },
+          grid: { color: 'rgba(255,255,255,0.1)' }
+        },
+        y: {
+          ticks: { color: '#f8f9fa' },
+          grid: { color: 'rgba(255,255,255,0.1)' }
+        }
+      }
+    }
+  });
+}

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -156,6 +156,10 @@ function applyRange() {
 
   buildPieChart("freq_chart", eventFreq);
   buildPieChart("manoeuvre_chart", manoeuvreFreq);
+
+  if (typeof buildBoxplot === 'function') {
+    buildBoxplot(range);
+  }
 }
 
 applyRange();

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-box-and-violin-plot@4.0.0/build/Chart.BoxPlot.min.js"></script>
   <style>
     body {
       background: #121212;
@@ -62,6 +63,14 @@
 
     <div id="charts" class="row"></div>
 
+    <div class="row mt-4">
+      <div class="col-12">
+        <div class="card p-3 chart-container">
+          <canvas id="boxplot_chart"></canvas>
+        </div>
+      </div>
+    </div>
+
     <div class="mt-5">
       <h2 class="mb-3">Fahrereignisse und Manöver</h2>
       <table class="table table-bordered table-sm" id="eventTable">
@@ -77,5 +86,6 @@
   </script>
   <script src="{{ url_for('static', filename='js/calculate.js') }}"></script>
   <script src="{{ url_for('static', filename='js/chart.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/boxplot.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `boxplot.js` to draw distributions using the Chart.js boxplot plugin
- call `buildBoxplot` from `chart.js`
- include a new canvas for boxplots and load the plugin in `chart.html`
- fix CDN path for the boxplot plugin

## Testing
- `python3 -m py_compile app.py Test_Set.py`


------
https://chatgpt.com/codex/tasks/task_e_686d083459f8833191e8f0475a91d828