### PR TITLE
Fix boxplot initialization order

### DIFF
--- a/templates/chart.html
+++ b/templates/chart.html
@@ -7,8 +7,6 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="{{ url_for('static', filename='js/chartjs-chart-boxplot.min.js') }}"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-box-and-violin-plot@4.0.0/build/Chart.BoxPlot.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-box-and-violin-plot"></script>
   <style>
     body {
       background: #121212;
@@ -87,7 +85,7 @@
     const sFull = {{ series|tojson|safe }};
   </script>
   <script src="{{ url_for('static', filename='js/calculate.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/chart.js') }}"></script>
   <script src="{{ url_for('static', filename='js/boxplot.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/chart.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove duplicated plugin scripts
- load `boxplot.js` before `chart.js`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d0c319d708331a2c3013d007819a4