### PR TITLE
Add horizontal boxplots per chart

### DIFF
--- a/static/js/boxplot.js
+++ b/static/js/boxplot.js
@@ -1,49 +1,49 @@
 'use strict';
 
-let boxplotRef = null;
+const boxplotRefs = {};
 
 function buildBoxplot(range) {
-  const ctx = document.getElementById('boxplot_chart').getContext('2d');
-  if (boxplotRef) boxplotRef.destroy();
+  chartData.forEach(([id, label, data]) => {
+    const canvas = document.getElementById(`boxplot_${id}`);
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (boxplotRefs[id]) boxplotRefs[id].destroy();
 
-  const slicedData = chartData.map(([id, label, data]) => {
-    return {
-      label: label,
-      data: data.slice(range[0], range[1])
-    };
-  }).filter(d => d.data.length > 0);
+    const sliced = data.slice(range[0], range[1]);
 
-  boxplotRef = new Chart(ctx, {
-    type: 'boxplot',
-    data: {
-      labels: slicedData.map(d => d.label),
-      datasets: [{
-        label: 'Verteilung',
-        backgroundColor: '#3498db',
-        borderColor: '#2980b9',
-        borderWidth: 1,
-        outlierColor: '#e74c3c',
-        padding: 10,
-        itemRadius: 0,
-        data: slicedData.map(d => d.data)
-      }]
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      plugins: {
-        legend: { labels: { color: '#f8f9fa' } }
+    boxplotRefs[id] = new Chart(ctx, {
+      type: 'boxplot',
+      data: {
+        labels: [label],
+        datasets: [{
+          label: 'Verteilung',
+          backgroundColor: '#3498db',
+          borderColor: '#2980b9',
+          borderWidth: 1,
+          outlierColor: '#e74c3c',
+          padding: 5,
+          itemRadius: 0,
+          data: [sliced]
+        }]
       },
-      scales: {
-        x: {
-          ticks: { color: '#f8f9fa' },
-          grid: { color: 'rgba(255,255,255,0.1)' }
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        indexAxis: 'y',
+        plugins: {
+          legend: { display: false }
         },
-        y: {
-          ticks: { color: '#f8f9fa' },
-          grid: { color: 'rgba(255,255,255,0.1)' }
+        scales: {
+          x: {
+            ticks: { color: '#f8f9fa' },
+            grid: { color: 'rgba(255,255,255,0.1)' }
+          },
+          y: {
+            ticks: { color: '#f8f9fa' },
+            grid: { color: 'rgba(255,255,255,0.1)' }
+          }
         }
       }
-    }
+    });
   });
 }

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -37,7 +37,8 @@ function insertChartBoxes() {
           Spannweite: <span id="range_${id}">-</span> |
           IQA: <span id="iqr_${id}">-</span>
         </div>
-        <div class="chart-container"><canvas id="${id}"></canvas></div>
+        <div class="chart-container mb-2"><canvas id="${id}"></canvas></div>
+        <div class="boxplot-container"><canvas id="boxplot_${id}"></canvas></div>
       </div>`;
     container.appendChild(col);
   }

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -40,6 +40,10 @@
       min-height: 400px;
       height: 420px;
     }
+    .boxplot-container {
+      min-height: 200px;
+      height: 220px;
+    }
   </style>
 </head>
 <body>
@@ -62,14 +66,6 @@
     </div>
 
     <div id="charts" class="row"></div>
-
-    <div class="row mt-4">
-      <div class="col-12">
-        <div class="card p-3 chart-container">
-          <canvas id="boxplot_chart"></canvas>
-        </div>
-      </div>
-    </div>
 
     <div class="mt-5">
       <h2 class="mb-3">Fahrereignisse und Manöver</h2>


### PR DESCRIPTION
## Summary
- show boxplots under each chart instead of single chart at bottom
- make boxplots horizontal using `indexAxis: 'y'`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686d0f0670348331a4913a991ca39c1a