### PR TITLE
Add variance stats and reposition chart info

### DIFF
--- a/static/js/calculate.js
+++ b/static/js/calculate.js
@@ -1,7 +1,8 @@
 'use strict';
 
 function computeStats(data) {
-  const avg = (data.reduce((a, b) => a + b, 0) / data.length).toFixed(2);
+  const n = data.length;
+  const avgNum = data.reduce((a, b) => a + b, 0) / n;
   const sorted = [...data].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
   const median = sorted.length % 2 === 0
@@ -11,5 +12,18 @@ function computeStats(data) {
   const q1 = sorted[Math.floor(sorted.length * 0.25)];
   const q3 = sorted[Math.floor(sorted.length * 0.75)];
   const iqr = (q3 - q1).toFixed(2);
-  return { avg, median, rangeVal, iqr };
+
+  const varianceNum = data.reduce((sum, val) => sum + Math.pow(val - avgNum, 2), 0) / n;
+  const stdNum = Math.sqrt(varianceNum);
+  const varCoeffNum = avgNum !== 0 ? stdNum / avgNum : 0;
+
+  return {
+    avg: avgNum.toFixed(2),
+    median,
+    rangeVal,
+    iqr,
+    variance: varianceNum.toFixed(2),
+    stdDev: stdNum.toFixed(2),
+    varCoeff: varCoeffNum.toFixed(2)
+  };
 }

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -31,14 +31,17 @@ function insertChartBoxes() {
     col.className = "col-12 col-md-6";
     col.innerHTML = `
       <div class="card p-3">
-        <div class="stat-box">
+        <div class="chart-container mb-2"><canvas id="${id}"></canvas></div>
+        <div class="boxplot-container"><canvas id="boxplot_${id}"></canvas></div>
+        <div class="stat-box mt-2">
           Mittelwert: <span id="mean_${id}">-</span> |
           Median: <span id="median_${id}">-</span> |
           Spannweite: <span id="range_${id}">-</span> |
-          IQA: <span id="iqr_${id}">-</span>
+          IQA: <span id="iqr_${id}">-</span> |
+          Varianz: <span id="var_${id}">-</span> |
+          Std-Abw.: <span id="std_${id}">-</span> |
+          V-Koeff.: <span id="vcoeff_${id}">-</span>
         </div>
-        <div class="chart-container mb-2"><canvas id="${id}"></canvas></div>
-        <div class="boxplot-container"><canvas id="boxplot_${id}"></canvas></div>
       </div>`;
     container.appendChild(col);
   }
@@ -65,6 +68,9 @@ function buildChart(id, label, data, range) {
   document.getElementById(`median_${id}`).textContent = stats.median;
   document.getElementById(`range_${id}`).textContent = stats.rangeVal;
   document.getElementById(`iqr_${id}`).textContent = stats.iqr;
+  document.getElementById(`var_${id}`).textContent = stats.variance;
+  document.getElementById(`std_${id}`).textContent = stats.stdDev;
+  document.getElementById(`vcoeff_${id}`).textContent = stats.varCoeff;
 
   chartRefs[id] = new Chart(ctx, {
     type: 'line',

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -31,10 +31,11 @@
     .stat-box {
       padding: 16px;
       font-size: 1.1rem;
-      background-color: #1e1e1e;
-      border: 1px solid #2c2c2c;
+      background-color: #ffffff;
+      color: #000000;
+      border: 1px solid #cccccc;
       border-radius: 8px;
-      margin-bottom: 8px;
+      margin-top: 8px;
     }
     .chart-container {
       min-height: 400px;


### PR DESCRIPTION
## Summary
- calculate variance, standard deviation and coefficient of variation
- display the new statistics below each chart
- style statistic boxes with a white background

## Testing
- `python3 -m py_compile app.py Test_Set.py`
- `node -c static/js/calculate.js`
- `node -c static/js/chart.js`
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686d126dc320833188bfa68bf3eacc33