### PR TITLE
Add Lorenz curve visualization

### DIFF
--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -55,6 +55,15 @@ function insertChartBoxes() {
   pie2.className = "col-12 col-md-6";
   pie2.innerHTML = `<div class="card p-3 chart-container"><canvas id="manoeuvre_chart"></canvas></div>`;
   container.appendChild(pie2);
+
+  const lorenz = document.createElement("div");
+  lorenz.className = "col-12";
+  lorenz.innerHTML = `
+    <div class="card p-3">
+      <div class="chart-container"><canvas id="lorenz_chart"></canvas></div>
+      <div class="stat-box mt-2">Gini-Koeffizient: <span id="gini_coef">-</span></div>
+    </div>`;
+  container.appendChild(lorenz);
 }
 
 function buildChart(id, label, data, range) {
@@ -166,6 +175,10 @@ function applyRange() {
 
   if (typeof buildBoxplot === 'function') {
     buildBoxplot(range);
+  }
+
+  if (typeof buildLorenzChart === 'function') {
+    buildLorenzChart(range);
   }
 }
 

--- a/static/js/lorenz.js
+++ b/static/js/lorenz.js
@@ -1,0 +1,67 @@
+'use strict';
+
+let lorenzRef;
+
+function computeLorenz(data) {
+  const sorted = [...data].sort((a, b) => a - b);
+  const n = sorted.length;
+  const cum = [0];
+  for (let i = 0; i < n; i++) {
+    cum.push(cum[i] + sorted[i]);
+  }
+  const total = cum[n];
+  const xs = [0];
+  const ys = [0];
+  for (let i = 1; i <= n; i++) {
+    xs.push(i / n);
+    ys.push(cum[i] / total);
+  }
+  let area = 0;
+  for (let i = 1; i <= n; i++) {
+    area += (ys[i] + ys[i - 1]) * (xs[i] - xs[i - 1]);
+  }
+  const gini = (1 - area).toFixed(2);
+  return { xs, ys, gini };
+}
+
+function buildLorenzChart(range) {
+  const ctx = document.getElementById('lorenz_chart').getContext('2d');
+  if (lorenzRef) lorenzRef.destroy();
+  const slice = sFull.speed.slice(range[0], range[1]);
+  const { xs, ys, gini } = computeLorenz(slice);
+  document.getElementById('gini_coef').textContent = gini;
+  lorenzRef = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: xs,
+      datasets: [{
+        label: 'Lorenzkurve (Geschwindigkeit)',
+        data: ys,
+        borderColor: '#e67e22',
+        borderWidth: 2,
+        fill: false,
+        pointRadius: 0
+      }]
+    },
+    options: {
+      animation: false,
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          title: { display: true, text: 'Kumulierter Anteil Fahrzeuge', color: '#f8f9fa' },
+          ticks: { color: '#f8f9fa' },
+          grid: { color: 'rgba(255,255,255,0.1)' }
+        },
+        y: {
+          title: { display: true, text: 'Kumulierter Anteil Geschwindigkeit', color: '#f8f9fa' },
+          ticks: { color: '#f8f9fa' },
+          grid: { color: 'rgba(255,255,255,0.1)' }
+        }
+      },
+      plugins: {
+        legend: { labels: { color: '#f8f9fa' } }
+      }
+    }
+  });
+}

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -84,5 +84,6 @@
   <script src="{{ url_for('static', filename='js/calculate.js') }}"></script>
   <script src="{{ url_for('static', filename='js/boxplot.js') }}"></script>
   <script src="{{ url_for('static', filename='js/chart.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/lorenz.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend dashboard setup script to add Lorenz curve panel with Gini coefficient
- insert call for new graph when index range changes
- provide dedicated `lorenz.js` helper for Lorenz curve calculation

## Testing
- `python -m py_compile app.py Test_Set.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d137469188331a9b5d50fcd71688a