### PR TITLE
Fix closing braces in chart.js

### DIFF
--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -184,10 +184,10 @@ function applyRange() {
 
   if (typeof buildAllLorenz === 'function') {
     buildAllLorenz(range);
+  }
 
   if (typeof buildLorenzChart === 'function') {
     buildLorenzChart(range);
-
   }
 }
 


### PR DESCRIPTION
## Summary
- fix mismatched closing braces in `static/js/chart.js`

## Testing
- `python3 -m py_compile Test_Set.py`
- `python3 -m py_compile app.py`
- `node --check static/js/chart.js`


------
https://chatgpt.com/codex/tasks/task_e_686d1761a558833192b1a075b16526fd