### PR TITLE
Fix Lorenz chart loading

### DIFF
--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -190,5 +190,3 @@ function applyRange() {
     buildOverviewLorenzChart(range);
   }
 }
-
-applyRange();

--- a/templates/chart.html
+++ b/templates/chart.html
@@ -83,7 +83,10 @@
   </script>
   <script src="{{ url_for('static', filename='js/calculate.js') }}"></script>
   <script src="{{ url_for('static', filename='js/boxplot.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/chart.js') }}"></script>
   <script src="{{ url_for('static', filename='js/lorenz.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/chart.js') }}"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', applyRange);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure Lorenz curve JS functions are loaded before calling them
- trigger `applyRange()` once all scripts are ready

## Testing
- `python3 -m py_compile app.py`
- `flake8 app.py` *(fails: F401, E501, E302, E305)*
- `python3 Test_Set.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686d1e0de9b08331a98d2ea367fc807d