### PR TITLE
Add drive style analysis page

### DIFF
--- a/analyse/drive_style.html
+++ b/analyse/drive_style.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <title>Drive Style Analyse</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body { background:#121212; color:#fff; }
+    .card{ background:#1e1e1e; border:1px solid #2c2c2c; margin-bottom:24px; }
+    canvas{ width:100% !important; height:300px !important; }
+  </style>
+</head>
+<body>
+<div class="container py-4">
+  <h1 class="mb-4">Drive Style Analyse</h1>
+  <div class="row">
+    <div class="col-12 col-md-6">
+      <div class="card p-3">
+        <canvas id="timeline"></canvas>
+      </div>
+    </div>
+    <div class="col-12 col-md-6">
+      <div class="card p-3">
+        <canvas id="distribution"></canvas>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="drive_style.js"></script>
+</body>
+</html>

--- a/analyse/drive_style.js
+++ b/analyse/drive_style.js
@@ -1,0 +1,80 @@
+'use strict';
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('drive_style_output.json')
+    .then(r => r.json())
+    .then(renderCharts)
+    .catch(err => console.error('fetch failed', err));
+});
+
+function renderCharts(data) {
+  const labels = data.time || data.timestamp || data.index || [];
+  const values = data.style || data.value || data.values || [];
+
+  const ctx1 = document.getElementById('timeline').getContext('2d');
+  new Chart(ctx1, {
+    type: 'line',
+    data: {
+      labels: labels,
+      datasets: [{
+        label: 'Fahrstil',
+        data: values,
+        borderColor: '#1abc9c',
+        borderWidth: 2,
+        fill: false,
+        pointRadius: 0,
+        tension: 0.15
+      }]
+    },
+    options: {
+      animation: false,
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          title: { display: true, text: 'Zeit', color: '#f8f9fa' },
+          ticks: { color: '#f8f9fa' },
+          grid: { color: 'rgba(255,255,255,0.1)' }
+        },
+        y: {
+          title: { display: true, text: 'Fahrstil', color: '#f8f9fa' },
+          ticks: { color: '#f8f9fa' },
+          grid: { color: 'rgba(255,255,255,0.1)' }
+        }
+      },
+      plugins: { legend: { labels: { color: '#f8f9fa' } } }
+    }
+  });
+
+  const freq = {};
+  values.forEach(v => { freq[v] = (freq[v] || 0) + 1; });
+  const ctx2 = document.getElementById('distribution').getContext('2d');
+  new Chart(ctx2, {
+    type: 'bar',
+    data: {
+      labels: Object.keys(freq),
+      datasets: [{
+        label: 'Häufigkeit',
+        data: Object.values(freq),
+        backgroundColor: '#3498db',
+        borderColor: '#2980b9',
+        borderWidth: 1
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          ticks: { color: '#f8f9fa' },
+          grid: { color: 'rgba(255,255,255,0.1)' }
+        },
+        y: {
+          ticks: { color: '#f8f9fa' },
+          grid: { color: 'rgba(255,255,255,0.1)' }
+        }
+      },
+      plugins: { legend: { labels: { color: '#f8f9fa' } } }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add standalone Drive Style analysis page
- fetch JSON data and plot timeline and distribution charts

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d5a5d3d2c8331bb1ea66c2a83b023