### PR TITLE
Add floating average overlay

### DIFF
--- a/static/js/calculate.js
+++ b/static/js/calculate.js
@@ -27,3 +27,14 @@ function computeStats(data) {
     varCoeff: varCoeffNum.toFixed(2)
   };
 }
+
+function computeMovingAverage(data, window) {
+  const result = [];
+  for (let i = 0; i < data.length; i++) {
+    const start = Math.max(0, i - window + 1);
+    const slice = data.slice(start, i + 1);
+    const avg = slice.reduce((sum, v) => sum + v, 0) / slice.length;
+    result.push(Number(avg.toFixed(2)));
+  }
+  return result;
+}

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -28,6 +28,7 @@ const chartData = [
 ];
 
 const chartRefs = {};
+const MA_WINDOW = 10;
 
 function insertChartBoxes() {
   const container = document.getElementById("charts");
@@ -82,6 +83,7 @@ function buildChart(id, label, data, range) {
 
   const sliced = data.slice(range[0], range[1]);
   const styles = driveStyleData.slice(range[0], range[1]);
+  const movingAvg = computeMovingAverage(sliced, MA_WINDOW);
   const stats = computeStats(sliced);
 
   document.getElementById(`mean_${id}`).textContent = stats.avg;
@@ -105,6 +107,16 @@ function buildChart(id, label, data, range) {
           pointRadius: 0,
           tension: 0.15,
           fill: false
+        },
+        {
+          label: 'Gleitender Mittelwert',
+          data: movingAvg,
+          borderColor: '#f1c40f',
+          borderWidth: 2,
+          pointRadius: 0,
+          tension: 0.15,
+          fill: false,
+          borderDash: [5, 5]
         },
         {
           type: 'scatter',


### PR DESCRIPTION
## Summary
- compute moving average in `calculate.js`
- render moving average as dashed line on every chart

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7f3d69d08331b2a8998d794305fa