### PR TITLE
Implement Leaflet map for GPS data

### DIFF
--- a/Instructions/README.md
+++ b/Instructions/README.md
@@ -26,8 +26,6 @@ python app.py
 
 The application will start a local development server and open `http://localhost:5000/`,
 which provides links to the available views.  The interactive chart is accessible
-
-at `http://localhost:5000/chart`.  Additional analysis pages are served at
+at `http://localhost:5000/chart` and now displays the GPS route on an interactive
+Leaflet map.  Additional analysis pages are served at
 `/zweidimensionale_analyse.html` and `/analyse/drive_style.html`.
-
-at `http://localhost:5000/chart`.

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// Initialize a Leaflet map with the GPS data and display the route.
 document.addEventListener('DOMContentLoaded', () => {
   if (!window.sFull) return;
 
@@ -7,21 +8,26 @@ document.addEventListener('DOMContentLoaded', () => {
   const lons = sFull.gps_lon || [];
   if (!lats.length || !lons.length) return;
 
+  const coords = lats.map((lat, i) => [lat, lons[i]]);
+
+  const map = L.map('mapCanvas');
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '© OpenStreetMap contributors'
+  }).addTo(map);
+
+  const polyline = L.polyline(coords, { color: 'orange' }).addTo(map);
+
   const minLat = Math.min(...lats);
   const maxLat = Math.max(...lats);
   const minLon = Math.min(...lons);
   const maxLon = Math.max(...lons);
 
-  const canvas = document.getElementById('mapCanvas');
-  if (!canvas) return;
-  const ctx = canvas.getContext('2d');
-  ctx.strokeStyle = 'orange';
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  lats.forEach((lat, i) => {
-    const x = (lons[i] - minLon) / (maxLon - minLon) * canvas.width;
-    const y = canvas.height - (lat - minLat) / (maxLat - minLat) * canvas.height;
-    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-  });
-  ctx.stroke();
+  const buffer = 0.0001;
+  const southWest = [minLat === maxLat ? minLat - buffer : minLat,
+                     minLon === maxLon ? minLon - buffer : minLon];
+  const northEast = [maxLat === minLat ? maxLat + buffer : maxLat,
+                     maxLon === minLon ? maxLon + buffer : maxLon];
+
+  map.fitBounds([southWest, northEast]);
 });

--- a/template/chart.html
+++ b/template/chart.html
@@ -91,7 +91,7 @@
         <tbody></tbody>
       </table>
       <div id="map" class="mt-4">
-        <canvas id="mapCanvas" width="600" height="500" style="width:100%;height:100%;background:#e0e0e0;"></canvas>
+        <div id="mapCanvas" style="width:100%;height:100%;background:#e0e0e0;"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- display the map in `chart.html` using a `<div>` element
- replace the canvas based map drawing with Leaflet logic
- note Leaflet map in the README

## Testing
- `pip install -r Instructions/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d848dd6c08331b5acb3c265525ccf