### PR TITLE
Integrate async 2D regression charts

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,5 +79,12 @@ def drive_style_api():
     data = compute_drive_style_series(str(CSV_PATH))
     return jsonify(data)
 
+
+@app.route("/api/regression_pairs")
+def regression_pairs_api():
+    """Return regression analysis pairs as JSON."""
+    data = load_analysis_results()
+    return jsonify(data)
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/static/js/regression.js
+++ b/static/js/regression.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const regressionPairsLabels = {
+  "speed_m_s_vs_rpm": ["speed_m_s", "rpm"],
+  "speed_m_s_vs_distance_m": ["speed_m_s", "distance_m"],
+  "speed_m_s_vs_steering_deg": ["speed_m_s", "steering_deg"],
+  "speed_m_s_vs_lateral_acc_m_s2": ["speed_m_s", "lateral_acc_m_s2"],
+  "accel_m_s2_vs_rpm": ["accel_m_s2", "rpm"],
+  "steering_deg_vs_lateral_acc_m_s2": ["steering_deg", "lateral_acc_m_s2"],
+  "speed_m_s_vs_distance_front_m": ["speed_m_s", "distance_front_m"],
+  "speed_m_s_vs_battery_pct": ["speed_m_s", "battery_pct"]
+};
+
+let regressionData = {};
+
+function loadRegressionPairs() {
+  return fetch('/api/regression_pairs')
+    .then(r => r.json())
+    .then(d => { regressionData = d; });
+}
+
+function makeRegressionCard(id) {
+  const col = document.createElement('div');
+  col.className = 'col-12 col-md-6';
+  col.innerHTML = `<div class='card p-3'>\n<canvas id='reg_${id}'></canvas>\n<div class='stat-box mt-2' id='reg_stat_${id}'></div>\n</div>`;
+  document.getElementById('regressionCharts').appendChild(col);
+}
+
+function buildRegressionCharts() {
+  for (const key in regressionPairsLabels) {
+    const obj = regressionData[key];
+    if (!obj) continue;
+    makeRegressionCard(key);
+    const ctx = document.getElementById('reg_' + key).getContext('2d');
+    const [xLab, yLab] = regressionPairsLabels[key];
+    const pts = obj.x.map((v, i) => ({ x: v, y: obj.y[i] }));
+    const minX = Math.min(...obj.x);
+    const maxX = Math.max(...obj.x);
+    const line = [
+      { x: minX, y: obj.intercept + obj.slope * minX },
+      { x: maxX, y: obj.intercept + obj.slope * maxX }
+    ];
+    new Chart(ctx, {
+      type: 'scatter',
+      data: {
+        datasets: [
+          { label: `${yLab} zu ${xLab}`, data: pts, backgroundColor: '#1abc9c' },
+          { label: 'Regression', data: line, type: 'line', fill: false, borderColor: '#e74c3c' }
+        ]
+      },
+      options: {
+        animation: false,
+        responsive: true,
+        plugins: { legend: { labels: { color: '#fff' } } },
+        scales: {
+          x: { title: { display: true, text: xLab, color: '#fff' }, ticks: { color: '#fff' }, grid: { color: 'rgba(255,255,255,0.1)' } },
+          y: { title: { display: true, text: yLab, color: '#fff' }, ticks: { color: '#fff' }, grid: { color: 'rgba(255,255,255,0.1)' } }
+        }
+      }
+    });
+    document.getElementById('reg_stat_' + key).textContent =
+      `ŷ = ${obj.intercept.toFixed(2)} + ${obj.slope.toFixed(2)}·x | r=${obj.r.toFixed(2)} | R²=${obj.r2.toFixed(2)}`;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadRegressionPairs().then(buildRegressionCharts);
+});
+

--- a/template/chart.html
+++ b/template/chart.html
@@ -94,6 +94,11 @@
         <canvas id="mapCanvas" width="600" height="500" style="width:100%;height:100%;background:#e0e0e0;"></canvas>
       </div>
     </div>
+
+    <div class="mt-5" id="regressionSection">
+      <h2 class="mb-3">2D Daten Datentypen</h2>
+      <div id="regressionCharts" class="row"></div>
+    </div>
   </div>
 
   <script>
@@ -106,6 +111,7 @@
   <script src="{{ url_for('static', filename='js/chart.js') }}"></script>
   <script src="{{ url_for('static', filename='js/drive_style.js') }}"></script>
   <script src="{{ url_for('static', filename='js/map.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/regression.js') }}"></script>
   <script>
     document.addEventListener('DOMContentLoaded', applyRange);
   </script>

--- a/tests/test_regression_pairs.py
+++ b/tests/test_regression_pairs.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import tempfile
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, REPO_ROOT)
+sys.path.insert(0, os.path.join(REPO_ROOT, "Driving Data"))
+
+from analysis_utils import compute_regression_pairs, PAIRS
+from Test_Set import simulate_drive_data
+from app import app
+
+
+def test_compute_regression_pairs_returns_keys():
+    df = simulate_drive_data(n=20, seed=0)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp:
+        df.to_csv(tmp.name, index=False)
+        path = tmp.name
+    try:
+        result = compute_regression_pairs(path)
+    finally:
+        os.remove(path)
+    assert isinstance(result, dict)
+    for x, y in PAIRS:
+        assert f"{x}_vs_{y}" in result
+
+
+def test_api_regression_pairs():
+    client = app.test_client()
+    resp = client.get("/api/regression_pairs")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, dict)
+    k = f"{PAIRS[0][0]}_vs_{PAIRS[0][1]}"
+    assert k in data
+


### PR DESCRIPTION
## Summary
- expose regression pair data as `/api/regression_pairs`
- fetch and display regression charts in Chart view
- include new JS for regression charts and HTML section
- test regression pair utility and API

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d84fa6f1083318a4c9a4206453fb0