### PR TITLE
Add aggregate metrics by weather and terrain

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "Driving Data"))
 
 from analysis_utils import compute_regression_pairs, compute_drive_style_series
 
+
 # CSV data is stored inside the "Data Base" directory
 CSV_PATH = Path(__file__).resolve().parent / "Data Base" / "fahrtanalyse_daten.csv"
 
@@ -39,6 +40,34 @@ def load_series():
     }
 
 
+def load_aggregates():
+    """Compute average metrics grouped by weather condition and terrain type."""
+    df = pd.read_csv(CSV_PATH)
+    numeric = [
+        "speed_m_s",
+        "rpm",
+        "steering_deg",
+        "distance_m",
+        "accel_m_s2",
+        "lateral_acc_m_s2",
+        "battery_pct",
+        "distance_front_m",
+    ]
+    by_weather = (
+        df.groupby("weather_condition")[numeric]
+        .mean()
+        .round(2)
+        .to_dict(orient="index")
+    )
+    by_terrain = (
+        df.groupby("terrain_type")[numeric]
+        .mean()
+        .round(2)
+        .to_dict(orient="index")
+    )
+    return {"by_weather": by_weather, "by_terrain": by_terrain}
+
+
 def load_analysis_results():
     """Return regression analysis data computed from the CSV."""
     return compute_regression_pairs(str(CSV_PATH))
@@ -52,7 +81,8 @@ def index():
 def chart():
     idx, series = load_series()
     analysis = load_analysis_results()
-    return render_template("chart.html", idx=idx, series=series, analysis=analysis)
+    aggregates = load_aggregates()
+    return render_template("chart.html", idx=idx, series=series, analysis=analysis, aggregates=aggregates)
 
 
 @app.route("/zweidimensionale_analyse.html")
@@ -84,6 +114,13 @@ def drive_style_api():
 def regression_pairs_api():
     """Return regression analysis pairs as JSON."""
     data = load_analysis_results()
+    return jsonify(data)
+
+
+@app.route("/api/aggregates")
+def aggregates_api():
+    """Return aggregated metrics by weather and terrain."""
+    data = load_aggregates()
     return jsonify(data)
 
 if __name__ == "__main__":

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -30,6 +30,8 @@ const chartData = [
 const chartRefs = {};
 const histogramRefs = {};
 const fftRefs = {};
+const aggregateChartRefs = {};
+const sequenceChartRefs = {};
 const MA_WINDOW = 10;
 
 function insertChartBoxes() {
@@ -315,3 +317,97 @@ function applyRange() {
   buildFFTChart('fft_speed', sFull.speed.slice(start, end));
   buildFFTChart('fft_accel', sFull.accel.slice(start, end));
 }
+
+function buildAggregateChart(id, labels, values) {
+  const ctx = document.getElementById(id).getContext('2d');
+  if (aggregateChartRefs[id]) aggregateChartRefs[id].destroy();
+  aggregateChartRefs[id] = new Chart(ctx, {
+    type: 'bar',
+    data: { labels: labels, datasets: [{ label: 'Geschwindigkeit (m/s)', data: values, backgroundColor: '#1abc9c' }] },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: { ticks: { color: '#f8f9fa' }, grid: { color: 'rgba(255,255,255,0.1)' } },
+        y: { ticks: { color: '#f8f9fa' }, grid: { color: 'rgba(255,255,255,0.1)' }, title: { display: true, text: 'Geschwindigkeit (m/s)', color: '#f8f9fa' } }
+      },
+      plugins: { legend: { labels: { color: '#f8f9fa' } } }
+    }
+  });
+}
+
+function buildSequenceChart(id, dataArray) {
+  const ctx = document.getElementById(id).getContext('2d');
+  const categories = Array.from(new Set(dataArray));
+  const mapping = {};
+  categories.forEach((k, i) => { mapping[k] = i; });
+  const numeric = dataArray.map(v => mapping[v]);
+  const labels = labelsFull.map(String);
+  if (sequenceChartRefs[id]) sequenceChartRefs[id].destroy();
+  sequenceChartRefs[id] = new Chart(ctx, {
+    type: 'line',
+    data: { labels: labels, datasets: [{ label: id, data: numeric, stepped: true, borderColor: '#3498db', pointRadius: 0, fill: false }] },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: { title: { display: true, text: 'Index', color: '#f8f9fa' }, ticks: { color: '#f8f9fa' }, grid: { color: 'rgba(255,255,255,0.1)' } },
+        y: {
+          ticks: { callback: v => categories[v], color: '#f8f9fa' },
+          grid: { color: 'rgba(255,255,255,0.1)' },
+          title: { display: true, text: 'Kategorie', color: '#f8f9fa' }
+        }
+      },
+      plugins: { legend: { labels: { color: '#f8f9fa' } } }
+    }
+  });
+}
+
+function updateAggregateCharts() {
+  if (typeof aggregatesData === 'undefined') return;
+  const wSel = document.getElementById('weatherSelect');
+  const tSel = document.getElementById('terrainSelect');
+  const wKeys = Array.from(wSel.selectedOptions).map(o => o.value);
+  const tKeys = Array.from(tSel.selectedOptions).map(o => o.value);
+  const weatherLabels = wKeys.length ? wKeys : Object.keys(aggregatesData.by_weather);
+  const terrainLabels = tKeys.length ? tKeys : Object.keys(aggregatesData.by_terrain);
+
+  const weatherPairs = weatherLabels.map(k => [k, aggregatesData.by_weather[k].speed_m_s]);
+  const terrainPairs = terrainLabels.map(k => [k, aggregatesData.by_terrain[k].speed_m_s]);
+  weatherPairs.sort((a, b) => b[1] - a[1]);
+  terrainPairs.sort((a, b) => b[1] - a[1]);
+
+  const sortedWeatherLabels = weatherPairs.map(p => p[0]);
+  const sortedWeatherValues = weatherPairs.map(p => p[1]);
+  const sortedTerrainLabels = terrainPairs.map(p => p[0]);
+  const sortedTerrainValues = terrainPairs.map(p => p[1]);
+  buildAggregateChart('weatherAggChart', sortedWeatherLabels, sortedWeatherValues);
+  buildAggregateChart('terrainAggChart', sortedTerrainLabels, sortedTerrainValues);
+}
+
+function initAggregateFilters() {
+  if (typeof aggregatesData === 'undefined') return;
+  const wSel = document.getElementById('weatherSelect');
+  const tSel = document.getElementById('terrainSelect');
+  Object.keys(aggregatesData.by_weather).forEach(k => {
+    const opt = document.createElement('option');
+    opt.value = k;
+    opt.textContent = k;
+    wSel.appendChild(opt);
+  });
+  Object.keys(aggregatesData.by_terrain).forEach(k => {
+    const opt = document.createElement('option');
+    opt.value = k;
+    opt.textContent = k;
+    tSel.appendChild(opt);
+  });
+  wSel.addEventListener('change', updateAggregateCharts);
+  tSel.addEventListener('change', updateAggregateCharts);
+  updateAggregateCharts();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initAggregateFilters();
+  buildSequenceChart('weatherSeqChart', sFull.weather_condition);
+  buildSequenceChart('terrainSeqChart', sFull.terrain_type);
+});

--- a/template/chart.html
+++ b/template/chart.html
@@ -58,6 +58,41 @@
     <h1 class="mb-2">Fahrtanalyse</h1>
     <p class="mb-4">Zeitreihenübersicht aller Sensorkanäle einer simulierten Fahrt.</p>
 
+    <div class="row mb-4">
+      <div class="col-sm-6 col-md-3">
+        <label class="form-label">Wetterauswahl</label>
+        <select id="weatherSelect" class="form-select" multiple></select>
+      </div>
+      <div class="col-sm-6 col-md-3">
+        <label class="form-label">Terrainauswahl</label>
+        <select id="terrainSelect" class="form-select" multiple></select>
+      </div>
+    </div>
+
+    <div class="mb-4" id="aggregateSection">
+      <h2 class="mb-3">Durchschnittswerte</h2>
+      <div class="row">
+        <div class="col-12 col-md-6">
+          <canvas id="weatherAggChart"></canvas>
+        </div>
+        <div class="col-12 col-md-6">
+          <canvas id="terrainAggChart"></canvas>
+        </div>
+      </div>
+    </div>
+
+    <div class="mb-4" id="sequenceSection">
+      <h2 class="mb-3">Verlauf von Wetter und Terrain</h2>
+      <div class="row">
+        <div class="col-12 col-md-6">
+          <canvas id="weatherSeqChart"></canvas>
+        </div>
+        <div class="col-12 col-md-6">
+          <canvas id="terrainSeqChart"></canvas>
+        </div>
+      </div>
+    </div>
+
     <div class="row mb-3">
       <div class="col-sm-6 col-md-3">
         <label class="form-label">Startindex</label>
@@ -104,6 +139,7 @@
   <script>
     const labelsFull = {{ idx|tojson|safe }};
     const sFull = {{ series|tojson|safe }};
+    const aggregatesData = {{ aggregates|tojson|safe }};
   </script>
   <script src="{{ url_for('static', filename='js/calculate.js') }}"></script>
   <script src="{{ url_for('static', filename='js/boxplot.js') }}"></script>

--- a/tests/test_aggregates_api.py
+++ b/tests/test_aggregates_api.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, REPO_ROOT)
+
+from app import app
+
+
+def test_api_aggregates():
+    client = app.test_client()
+    resp = client.get("/api/aggregates")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "by_weather" in data
+    assert "by_terrain" in data
+    assert isinstance(data["by_weather"], dict)
+    assert isinstance(data["by_terrain"], dict)
+    assert data["by_weather"]
+    assert data["by_terrain"]
+    first = next(iter(data["by_weather"].values()))
+    assert "speed_m_s" in first


### PR DESCRIPTION
## Summary
- compute aggregated mean metrics grouped by weather_condition and terrain_type
- expose new `/api/aggregates` endpoint
- render dropdown filters and new charts for weather and terrain at the top
- add sequence charts for weather and terrain categories
- sort aggregate bars by average speed
- add unit test for the aggregates API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d8b226a6c8331b8a5e0d7faf9755c