### PR TITLE
Remove FFT analysis charts

### DIFF
--- a/static/js/calculate.js
+++ b/static/js/calculate.js
@@ -38,3 +38,35 @@ function computeMovingAverage(data, window) {
   }
   return result;
 }
+function computeHistogram(data, bins = 10) {
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const width = (max - min) / bins || 1;
+  const counts = new Array(bins).fill(0);
+  for (const v of data) {
+    const idx = Math.min(Math.floor((v - min) / width), bins - 1);
+    counts[idx]++;
+  }
+  const labels = counts.map((_, i) => (min + i * width).toFixed(2));
+  return { labels, counts };
+}
+
+function computeTrend(data) {
+  const n = data.length;
+  const meanX = (n - 1) / 2;
+  const meanY = data.reduce((a, b) => a + b, 0) / n;
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < n; i++) {
+    num += (i - meanX) * (data[i] - meanY);
+    den += (i - meanX) * (i - meanX);
+  }
+  const slope = den ? num / den : 0;
+  const intercept = meanY - slope * meanX;
+  const trend = [];
+  for (let i = 0; i < n; i++) {
+    trend.push(Number((intercept + slope * i).toFixed(2)));
+  }
+  return { slope, intercept, trend };
+}
+

--- a/static/js/chart.js
+++ b/static/js/chart.js
@@ -28,6 +28,7 @@ const chartData = [
 ];
 
 const chartRefs = {};
+const histogramRefs = {};
 const MA_WINDOW = 10;
 
 function insertChartBoxes() {
@@ -40,6 +41,7 @@ function insertChartBoxes() {
       <div class="card p-3">
         <div class="chart-container mb-2"><canvas id="${id}"></canvas></div>
         <div class="chart-container mb-2"><canvas id="lorenz_${id}"></canvas></div>
+        <div class="chart-container mb-2"><canvas id="hist_${id}"></canvas></div>
         <div class="boxplot-container"><canvas id="boxplot_${id}"></canvas></div>
         <div class="stat-box mt-2">
           Mittelwert: <span id="mean_${id}">-</span> |
@@ -49,7 +51,8 @@ function insertChartBoxes() {
           Varianz: <span id="var_${id}">-</span> |
           Std-Abw.: <span id="std_${id}">-</span> |
           V-Koeff.: <span id="vcoeff_${id}">-</span><br>
-          Gini: <span id="gini_${id}">-</span>
+          Gini: <span id="gini_${id}">-</span> |
+          Trend: <span id="trend_${id}">-</span>
         </div>
       </div>`;
     container.appendChild(col);
@@ -75,6 +78,8 @@ function insertChartBoxes() {
     </div>`;
   container.appendChild(lorenz);
 
+  /* FFT charts removed */
+
 }
 
 function buildChart(id, label, data, range) {
@@ -84,6 +89,7 @@ function buildChart(id, label, data, range) {
   const sliced = data.slice(range[0], range[1]);
   const styles = driveStyleData.slice(range[0], range[1]);
   const movingAvg = computeMovingAverage(sliced, MA_WINDOW);
+  const trend = computeTrend(sliced);
   const stats = computeStats(sliced);
 
   document.getElementById(`mean_${id}`).textContent = stats.avg;
@@ -93,6 +99,7 @@ function buildChart(id, label, data, range) {
   document.getElementById(`var_${id}`).textContent = stats.variance;
   document.getElementById(`std_${id}`).textContent = stats.stdDev;
   document.getElementById(`vcoeff_${id}`).textContent = stats.varCoeff;
+  document.getElementById(`trend_${id}`).textContent = trend.slope.toFixed(2);
 
   chartRefs[id] = new Chart(ctx, {
     type: 'line',
@@ -117,6 +124,16 @@ function buildChart(id, label, data, range) {
           tension: 0.15,
           fill: false,
           borderDash: [5, 5]
+        },
+        {
+          label: 'Trendlinie',
+          data: trend.trend,
+          borderColor: '#e67e22',
+          borderWidth: 2,
+          pointRadius: 0,
+          tension: 0.15,
+          fill: false,
+          borderDash: [2, 2]
         },
         {
           type: 'scatter',
@@ -194,13 +211,40 @@ function buildPieChart(id, dataMap) {
   });
 }
 
+function buildHistogram(id, label, data, range) {
+  const ctx = document.getElementById(`hist_${id}`).getContext('2d');
+  if (histogramRefs[id]) histogramRefs[id].destroy();
+  const slice = data.slice(range[0], range[1]);
+  const hist = computeHistogram(slice, 20);
+  histogramRefs[id] = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: hist.labels,
+      datasets: [{ label: 'Häufigkeit', data: hist.counts, backgroundColor: '#9b59b6' }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: { ticks: { color: '#f8f9fa' }, grid: { color: 'rgba(255,255,255,0.1)' }, title: { display: true, text: label, color: '#f8f9fa' } },
+        y: { ticks: { color: '#f8f9fa' }, grid: { color: 'rgba(255,255,255,0.1)' }, title: { display: true, text: 'Anzahl', color: '#f8f9fa' } }
+      },
+      plugins: { legend: { labels: { color: '#f8f9fa' } } }
+    }
+  });
+}
+
+
 function applyRange() {
   const start = parseInt(document.getElementById('startIdx').value);
   const end = parseInt(document.getElementById('endIdx').value);
   const range = [start, end];
 
   insertChartBoxes();
-  chartData.forEach(([id, label, data]) => buildChart(id, label, data, range));
+  chartData.forEach(([id, label, data]) => {
+    buildChart(id, label, data, range);
+    buildHistogram(id, label, data, range);
+  });
 
   const tbody = document.querySelector("#eventTable tbody");
   tbody.innerHTML = "";
@@ -241,4 +285,6 @@ function applyRange() {
   if (typeof buildOverviewLorenzChart === 'function') {
     buildOverviewLorenzChart(range);
   }
+
+  /* FFT charts removed */
 }


### PR DESCRIPTION
## Summary
- strip FFT-based calculations and visualizations
- keep histograms and trendlines for each metric

## Testing
- `pip install -r Instructions/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d884cd5f48331a0f2f37b7232ee22