### PR TITLE
Add separate page for weather charts

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "Driving Data"))
 
 from analysis_utils import compute_regression_pairs, compute_drive_style_series
 
+
 # CSV data is stored inside the "Data Base" directory
 CSV_PATH = Path(__file__).resolve().parent / "Data Base" / "fahrtanalyse_daten.csv"
 
@@ -39,6 +40,34 @@ def load_series():
     }
 
 
+def load_aggregates():
+    """Compute average metrics grouped by weather condition and terrain type."""
+    df = pd.read_csv(CSV_PATH)
+    numeric = [
+        "speed_m_s",
+        "rpm",
+        "steering_deg",
+        "distance_m",
+        "accel_m_s2",
+        "lateral_acc_m_s2",
+        "battery_pct",
+        "distance_front_m",
+    ]
+    by_weather = (
+        df.groupby("weather_condition")[numeric]
+        .mean()
+        .round(2)
+        .to_dict(orient="index")
+    )
+    by_terrain = (
+        df.groupby("terrain_type")[numeric]
+        .mean()
+        .round(2)
+        .to_dict(orient="index")
+    )
+    return {"by_weather": by_weather, "by_terrain": by_terrain}
+
+
 def load_analysis_results():
     """Return regression analysis data computed from the CSV."""
     return compute_regression_pairs(str(CSV_PATH))
@@ -52,7 +81,16 @@ def index():
 def chart():
     idx, series = load_series()
     analysis = load_analysis_results()
-    return render_template("chart.html", idx=idx, series=series, analysis=analysis)
+    aggregates = load_aggregates()
+    return render_template("chart.html", idx=idx, series=series, analysis=analysis, aggregates=aggregates)
+
+
+@app.route("/terrain")
+def terrain_page():
+    """Separate page showing Wetterdaten charts."""
+    idx, series = load_series()
+    aggregates = load_aggregates()
+    return render_template("terrain.html", idx=idx, series=series, aggregates=aggregates)
 
 
 @app.route("/zweidimensionale_analyse.html")
@@ -84,6 +122,13 @@ def drive_style_api():
 def regression_pairs_api():
     """Return regression analysis pairs as JSON."""
     data = load_analysis_results()
+    return jsonify(data)
+
+
+@app.route("/api/aggregates")
+def aggregates_api():
+    """Return aggregated metrics by weather and terrain."""
+    data = load_aggregates()
     return jsonify(data)
 
 if __name__ == "__main__":

--- a/static/js/weather_charts.js
+++ b/static/js/weather_charts.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const aggregateChartRefs = {};
+const sequenceChartRefs = {};
+
+function buildAggregateChart(id, labels, values) {
+  const ctx = document.getElementById(id).getContext('2d');
+  if (aggregateChartRefs[id]) aggregateChartRefs[id].destroy();
+  aggregateChartRefs[id] = new Chart(ctx, {
+    type: 'bar',
+    data: { labels: labels, datasets: [{ label: 'Geschwindigkeit (m/s)', data: values, backgroundColor: '#1abc9c' }] },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: { ticks: { color: '#f8f9fa' }, grid: { color: 'rgba(255,255,255,0.1)' } },
+        y: { ticks: { color: '#f8f9fa' }, grid: { color: 'rgba(255,255,255,0.1)' }, title: { display: true, text: 'Geschwindigkeit (m/s)', color: '#f8f9fa' } }
+      },
+      plugins: { legend: { labels: { color: '#f8f9fa' } } }
+    }
+  });
+}
+
+function buildSequenceChart(id, dataArray) {
+  const ctx = document.getElementById(id).getContext('2d');
+  const categories = Array.from(new Set(dataArray));
+  const mapping = {};
+  categories.forEach((k, i) => { mapping[k] = i; });
+  const numeric = dataArray.map(v => mapping[v]);
+  const labels = labelsFull.map(String);
+  if (sequenceChartRefs[id]) sequenceChartRefs[id].destroy();
+  sequenceChartRefs[id] = new Chart(ctx, {
+    type: 'line',
+    data: { labels: labels, datasets: [{ label: id, data: numeric, stepped: true, borderColor: '#3498db', pointRadius: 0, fill: false }] },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: { title: { display: true, text: 'Index', color: '#f8f9fa' }, ticks: { color: '#f8f9fa' }, grid: { color: 'rgba(255,255,255,0.1)' } },
+        y: { ticks: { callback: v => categories[v], color: '#f8f9fa' }, grid: { color: 'rgba(255,255,255,0.1)' }, title: { display: true, text: 'Kategorie', color: '#f8f9fa' } }
+      },
+      plugins: { legend: { labels: { color: '#f8f9fa' } } }
+    }
+  });
+}
+
+function updateWeatherCharts() {
+  if (typeof aggregatesData === 'undefined') return;
+  const wSel = document.getElementById('weatherSelect');
+  const wKeys = Array.from(wSel.selectedOptions).map(o => o.value);
+  const weatherLabels = wKeys.length ? wKeys : Object.keys(aggregatesData.by_weather);
+
+  const weatherPairs = weatherLabels.map(k => [k, aggregatesData.by_weather[k].speed_m_s]);
+  weatherPairs.sort((a, b) => b[1] - a[1]);
+
+  const sortedLabels = weatherPairs.map(p => p[0]);
+  const sortedValues = weatherPairs.map(p => p[1]);
+  buildAggregateChart('weatherAggChart', sortedLabels, sortedValues);
+}
+
+function initWeatherFilters() {
+  if (typeof aggregatesData === 'undefined') return;
+  const wSel = document.getElementById('weatherSelect');
+  Object.keys(aggregatesData.by_weather).forEach(k => {
+    const opt = document.createElement('option');
+    opt.value = k;
+    opt.textContent = k;
+    wSel.appendChild(opt);
+  });
+  wSel.addEventListener('change', updateWeatherCharts);
+  updateWeatherCharts();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initWeatherFilters();
+  buildSequenceChart('weatherSeqChart', sFull.weather_condition);
+});

--- a/template/chart.html
+++ b/template/chart.html
@@ -58,6 +58,31 @@
     <h1 class="mb-2">Fahrtanalyse</h1>
     <p class="mb-4">Zeitreihenübersicht aller Sensorkanäle einer simulierten Fahrt.</p>
 
+    <div class="row mb-4">
+      <div class="col-sm-6 col-md-3">
+        <label class="form-label">Terrainauswahl</label>
+        <select id="terrainSelect" class="form-select" multiple></select>
+      </div>
+    </div>
+
+    <div class="mb-4" id="aggregateSection">
+      <h2 class="mb-3">Durchschnittswerte</h2>
+      <div class="row">
+        <div class="col-12 col-md-6">
+          <canvas id="terrainAggChart"></canvas>
+        </div>
+      </div>
+    </div>
+
+    <div class="mb-4" id="sequenceSection">
+      <h2 class="mb-3">Verlauf des Terrains</h2>
+      <div class="row">
+        <div class="col-12 col-md-6">
+          <canvas id="terrainSeqChart"></canvas>
+        </div>
+      </div>
+    </div>
+
     <div class="row mb-3">
       <div class="col-sm-6 col-md-3">
         <label class="form-label">Startindex</label>
@@ -83,7 +108,6 @@
             <th>Event-Code</th>
             <th>Manöver</th>
             <th>Terrain</th>
-            <th>Wetter</th>
             <th>Breitengrad</th>
             <th>Längengrad</th>
           </tr>
@@ -104,6 +128,7 @@
   <script>
     const labelsFull = {{ idx|tojson|safe }};
     const sFull = {{ series|tojson|safe }};
+    const aggregatesData = {{ aggregates|tojson|safe }};
   </script>
   <script src="{{ url_for('static', filename='js/calculate.js') }}"></script>
   <script src="{{ url_for('static', filename='js/boxplot.js') }}"></script>

--- a/template/index.html
+++ b/template/index.html
@@ -15,6 +15,9 @@
         <a href="/chart">Chart Ansicht</a>
       </li>
       <li class="list-group-item">
+        <a href="/terrain">Terrain/Wetter Daten</a>
+      </li>
+      <li class="list-group-item">
         <a href="zweidimensionale_analyse.html">Zweidimensionale Analyse</a>
       </li>
       <li class="list-group-item">

--- a/template/terrain.html
+++ b/template/terrain.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <title>Wetterauswertung</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body { background: #121212; color: #ffffff; overflow-x: hidden; }
+    canvas { width: 100% !important; height: 100% !important; }
+    h1, h2, p, label { color: #ffffff !important; }
+    .chart-container { min-height: 400px; height: 420px; }
+  </style>
+</head>
+<body>
+  <div class="container py-4">
+    <h1 class="mb-2">Wetterdaten</h1>
+    <p class="mb-4">Aggregierte Werte nach Wetterbedingungen.</p>
+
+    <div class="row mb-4">
+      <div class="col-sm-6 col-md-3">
+        <label class="form-label">Wetterauswahl</label>
+        <select id="weatherSelect" class="form-select" multiple></select>
+      </div>
+    </div>
+
+    <div class="mb-4">
+      <h2 class="mb-3">Durchschnittswerte</h2>
+      <div class="row">
+        <div class="col-12 col-md-6">
+          <canvas id="weatherAggChart"></canvas>
+        </div>
+      </div>
+    </div>
+
+    <div class="mb-4">
+      <h2 class="mb-3">Verlauf der Wetterbedingungen</h2>
+      <div class="row">
+        <div class="col-12 col-md-6">
+          <canvas id="weatherSeqChart"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const labelsFull = {{ idx|tojson|safe }};
+    const sFull = {{ series|tojson|safe }};
+    const aggregatesData = {{ aggregates|tojson|safe }};
+  </script>
+  <script src="{{ url_for('static', filename='js/weather_charts.js') }}"></script>
+</body>
+</html>

--- a/tests/test_aggregates_api.py
+++ b/tests/test_aggregates_api.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, REPO_ROOT)
+
+from app import app
+
+
+def test_api_aggregates():
+    client = app.test_client()
+    resp = client.get("/api/aggregates")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "by_weather" in data
+    assert "by_terrain" in data
+    assert isinstance(data["by_weather"], dict)
+    assert isinstance(data["by_terrain"], dict)
+    assert data["by_weather"]
+    assert data["by_terrain"]
+    first = next(iter(data["by_weather"].values()))
+    assert "speed_m_s" in first


### PR DESCRIPTION
## Summary
- remove weather charts from main chart page
- show terrain filters and charts only
- add new route and page `terrain.html` to present weather charts
- link new page from the start page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8b226a6c8331b8a5e0d7faf9755c