### PR TITLE
Add trajectory visualization page

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,6 +110,13 @@ def drive_style_api():
     return jsonify(data)
 
 
+@app.route("/api/series")
+def series_api():
+    """Return full time series data as JSON."""
+    idx, series = load_series()
+    return jsonify({"idx": idx, "series": series})
+
+
 @app.route("/api/regression_pairs")
 def regression_pairs_api():
     """Return regression analysis pairs as JSON."""
@@ -138,6 +145,22 @@ def aggregates_api():
     """Return aggregated metrics by weather and terrain."""
     data = load_aggregates()
     return jsonify(data)
+
+
+# ---------------------------------------------------------------
+# Trajectory visualisation
+# ---------------------------------------------------------------
+
+@app.route("/trajectory/")
+def trajectory_index():
+    """Serve the trajectory visualisation page."""
+    return send_from_directory(os.path.join(app.root_path, "trajectory"), "index.html")
+
+
+@app.route("/trajectory/<path:filename>")
+def trajectory_files(filename):
+    """Serve static files for the trajectory page."""
+    return send_from_directory(os.path.join(app.root_path, "trajectory"), filename)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/template/index.html
+++ b/template/index.html
@@ -20,6 +20,9 @@
       <li class="list-group-item">
         <a href="analyse/drive_style.html">Drive Style Analyse</a>
       </li>
+      <li class="list-group-item">
+        <a href="/trajectory/">Trajektorie Visualisierung</a>
+      </li>
     </ul>
   </div>
 </body>

--- a/trajectory/index.html
+++ b/trajectory/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <title>Trajektorie</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body, html { height:100%; margin:0; background:#000; color:#fff; }
+    #canvas { width:100%; height:100%; display:block; }
+  </style>
+</head>
+<body>
+  <canvas id="canvas"></canvas>
+  <script src="trajectory.js"></script>
+</body>
+</html>

--- a/trajectory/trajectory.js
+++ b/trajectory/trajectory.js
@@ -1,0 +1,65 @@
+'use strict';
+
+// Fetch movement data and render the 2D trajectory on a black canvas.
+
+function colorForSpeed(speed, maxSpeed) {
+  const ratio = maxSpeed ? speed / maxSpeed : 0;
+  const hue = (1 - ratio) * 240; // blue to red
+  return `hsl(${hue}, 100%, 50%)`;
+}
+
+function drawTrajectory(data) {
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+  // Resize canvas to fill window
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+
+  const speed = data.series.speed;
+  const steering = data.series.steering;
+  const accel = data.series.accel || [];
+  const dt = 1; // seconds per sample (assumed)
+  const steerFactor = Math.PI / 180 * 0.05; // convert deg -> rad with factor
+
+  const points = [{x:0, y:0, v:speed[0], a:accel[0]||0}];
+  let theta = 0;
+  for (let i = 0; i < speed.length; i++) {
+    const ds = speed[i] * dt;
+    const dtheta = steering[i] * steerFactor;
+    theta += dtheta;
+    const prev = points[points.length - 1];
+    const x = prev.x + ds * Math.cos(theta);
+    const y = prev.y + ds * Math.sin(theta);
+    points.push({x, y, v: speed[i], a: accel[i] || 0});
+  }
+
+  const xs = points.map(p => p.x);
+  const ys = points.map(p => p.y);
+  const minX = Math.min(...xs), maxX = Math.max(...xs);
+  const minY = Math.min(...ys), maxY = Math.max(...ys);
+  const margin = 10;
+  const scaleX = (canvas.width - 2 * margin) / (maxX - minX || 1);
+  const scaleY = (canvas.height - 2 * margin) / (maxY - minY || 1);
+  const maxSpeed = Math.max(...speed);
+
+  ctx.lineWidth = 2;
+  ctx.lineCap = 'round';
+
+  for (let i = 1; i < points.length; i++) {
+    const p0 = points[i - 1];
+    const p1 = points[i];
+    ctx.strokeStyle = colorForSpeed(p1.v, maxSpeed);
+    ctx.beginPath();
+    ctx.moveTo(margin + (p0.x - minX) * scaleX,
+               canvas.height - (margin + (p0.y - minY) * scaleY));
+    ctx.lineTo(margin + (p1.x - minX) * scaleX,
+               canvas.height - (margin + (p1.y - minY) * scaleY));
+    ctx.stroke();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('/api/series')
+    .then(r => r.json())
+    .then(drawTrajectory);
+});


### PR DESCRIPTION
## Summary
- implement new trajectory visualization available at `/trajectory/`
- provide API endpoint `/api/series` for timeseries
- add dashboard link

## Testing
- `pip install -r Instructions/requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d91a264948331a07a4d5083216b7d