### PR TITLE
Remove aggregate charts and frequency analysis

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,8 +16,11 @@ CSV_PATH = Path(__file__).resolve().parent / "Data Base" / "fahrtanalyse_daten.c
 
 # Templates are stored in the "template" directory
 app = Flask(__name__, template_folder="template")
-app.config['TEMPLATES_AUTO_RELOAD'] = True
-app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0  # Verhindert Browser-Caching statischer Dateien
+app.config["TEMPLATES_AUTO_RELOAD"] = True
+app.config["SEND_FILE_MAX_AGE_DEFAULT"] = (
+    0  # Verhindert Browser-Caching statischer Dateien
+)
+
 
 def load_series():
     df = pd.read_csv(CSV_PATH)
@@ -54,16 +57,10 @@ def load_aggregates():
         "distance_front_m",
     ]
     by_weather = (
-        df.groupby("weather_condition")[numeric]
-        .mean()
-        .round(2)
-        .to_dict(orient="index")
+        df.groupby("weather_condition")[numeric].mean().round(2).to_dict(orient="index")
     )
     by_terrain = (
-        df.groupby("terrain_type")[numeric]
-        .mean()
-        .round(2)
-        .to_dict(orient="index")
+        df.groupby("terrain_type")[numeric].mean().round(2).to_dict(orient="index")
     )
     return {"by_weather": by_weather, "by_terrain": by_terrain}
 
@@ -71,6 +68,7 @@ def load_aggregates():
 def load_analysis_results():
     """Return regression analysis data computed from the CSV."""
     return compute_regression_pairs(str(CSV_PATH))
+
 
 @app.route("/")
 def index():
@@ -81,34 +79,41 @@ def index():
 def chart():
     idx, series = load_series()
     analysis = load_analysis_results()
-    aggregates = load_aggregates()
-    return render_template("chart.html", idx=idx, series=series, analysis=analysis, aggregates=aggregates)
+    return render_template("chart.html", idx=idx, series=series, analysis=analysis)
+
 
 @app.route("/terrain")
 def terrain_page():
     """Separate page showing Wetterdaten charts."""
     idx, series = load_series()
     aggregates = load_aggregates()
-    return render_template("terrain.html", idx=idx, series=series, aggregates=aggregates)
-
+    return render_template(
+        "terrain.html", idx=idx, series=series, aggregates=aggregates
+    )
 
 
 @app.route("/zweidimensionale_analyse.html")
 def zweidimensionale_analyse():
     """Serve the zweidimensionale Analyse page."""
-    return send_from_directory(os.path.join(app.root_path, "Driving Analysis"), "zweidimensionale_analyse.html")
+    return send_from_directory(
+        os.path.join(app.root_path, "Driving Analysis"), "zweidimensionale_analyse.html"
+    )
 
 
 @app.route("/analyse/drive_style.html")
 def drive_style_html():
     """Serve the drive style analysis page."""
-    return send_from_directory(os.path.join(app.root_path, "Driving Analysis"), "drive_style.html")
+    return send_from_directory(
+        os.path.join(app.root_path, "Driving Analysis"), "drive_style.html"
+    )
 
 
 @app.route("/analyse/drive_style.js")
 def drive_style_js():
     """Serve the drive style script."""
-    return send_from_directory(os.path.join(app.root_path, "static/js"), "drive_style_analysis.js")
+    return send_from_directory(
+        os.path.join(app.root_path, "static/js"), "drive_style_analysis.js"
+    )
 
 
 @app.route("/api/drive_style")
@@ -132,11 +137,10 @@ def regression_pairs_api():
     return jsonify(data)
 
 
-
-
 # ---------------------------------------------------------------
 # Terrain map
 # ---------------------------------------------------------------
+
 
 @app.route("/terrain/")
 def terrain_index():
@@ -161,6 +165,7 @@ def aggregates_api():
 # Trajectory visualisation
 # ---------------------------------------------------------------
 
+
 @app.route("/trajectory/")
 def trajectory_index():
     """Serve the trajectory visualisation page."""
@@ -171,6 +176,7 @@ def trajectory_index():
 def trajectory_files(filename):
     """Serve static files for the trajectory page."""
     return send_from_directory(os.path.join(app.root_path, "trajectory"), filename)
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/static/js/calculate.js
+++ b/static/js/calculate.js
@@ -71,32 +71,4 @@ function computeTrend(data) {
 }
 
 
-function computeFFT(data) {
-  const n = data.length;
-  const mags = [];
-  for (let k = 0; k < n; k++) {
-    let re = 0;
-    let im = 0;
-    for (let t = 0; t < n; t++) {
-      const angle = (2 * Math.PI * t * k) / n;
-      re += data[t] * Math.cos(angle);
-      im -= data[t] * Math.sin(angle);
-    }
-    mags.push(Math.sqrt(re * re + im * im) / n);
-  }
-  return mags.slice(0, Math.floor(n / 2));
-}
-
-function computeDominantFreqIndex(data) {
-  const mags = computeFFT(data);
-  let max = -Infinity;
-  let idx = 0;
-  for (let i = 0; i < mags.length; i++) {
-    if (mags[i] > max) {
-      max = mags[i];
-      idx = i;
-    }
-  }
-  return idx;
-}
 

--- a/template/chart.html
+++ b/template/chart.html
@@ -58,28 +58,6 @@
     <h1 class="mb-2">Fahrtanalyse</h1>
     <p class="mb-4">Zeitreihenübersicht aller Sensorkanäle einer simulierten Fahrt.</p>
 
-    <div class="row mb-4">
-      <div class="col-sm-6 col-md-3">
-        <label class="form-label">Wetterauswahl</label>
-        <select id="weatherSelect" class="form-select" multiple></select>
-      </div>
-      <div class="col-sm-6 col-md-3">
-        <label class="form-label">Terrainauswahl</label>
-        <select id="terrainSelect" class="form-select" multiple></select>
-      </div>
-    </div>
-
-    <div class="mb-4" id="aggregateSection">
-      <h2 class="mb-3">Durchschnittswerte</h2>
-      <div class="row">
-        <div class="col-12 col-md-6">
-          <canvas id="weatherAggChart"></canvas>
-        </div>
-        <div class="col-12 col-md-6">
-          <canvas id="terrainAggChart"></canvas>
-        </div>
-      </div>
-    </div>
 
     <div class="mb-4" id="sequenceSection">
       <h2 class="mb-3">Verlauf von Wetter und Terrain</h2>
@@ -107,17 +85,6 @@
       </div>
     </div>
 
-    <div class="row mb-4">
-      <div class="col-sm-6 col-md-3">
-        <label class="form-label">Wetterauswahl</label>
-        <select id="weatherSelect" class="form-select" multiple></select>
-      </div>
-      <div class="col-sm-6 col-md-3">
-        <label class="form-label">Terrainauswahl</label>
-        <select id="terrainSelect" class="form-select" multiple></select>
-      </div>
-    </div>
-
     <div id="charts" class="row"></div>
 
     <div class="mt-5">
@@ -141,18 +108,6 @@
       </div>
     </div>
 
-    <div class="mt-5" id="aggregateSection">
-      <h2 class="mb-3">Durchschnittswerte</h2>
-      <div class="row">
-        <div class="col-12 col-md-6">
-          <canvas id="weatherAggChart"></canvas>
-        </div>
-        <div class="col-12 col-md-6">
-          <canvas id="terrainAggChart"></canvas>
-        </div>
-      </div>
-    </div>
-
     <div class="mt-5" id="regressionSection">
       <h2 class="mb-3">2D Daten Datentypen</h2>
       <div id="regressionCharts" class="row"></div>
@@ -162,7 +117,6 @@
   <script>
     const labelsFull = {{ idx|tojson|safe }};
     const sFull = {{ series|tojson|safe }};
-    const aggregatesData = {{ aggregates|tojson|safe }};
   </script>
   <script src="{{ url_for('static', filename='js/calculate.js') }}"></script>
   <script src="{{ url_for('static', filename='js/boxplot.js') }}"></script>


### PR DESCRIPTION
## Summary
- drop weather and terrain selection from main chart page
- remove aggregated charts and frequency index charts
- simplify chart.js without FFT logic
- update backend to stop passing aggregate data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d9c9e98c483319c2117aa39eb521a